### PR TITLE
Allow deletion of frozen fields

### DIFF
--- a/semimutable/__init__.py
+++ b/semimutable/__init__.py
@@ -94,6 +94,17 @@ class FrozenField[T]:
 
         setattr(instance, self._private_name, value)
 
+    def __delete__(self, instance: object) -> None:
+        try:
+            delattr(instance, self._private_name)
+        except AttributeError:
+            pass
+        public_name = self._private_name[len(FROZEN_PREFIX) :]
+        try:
+            instance.__dict__.pop(public_name, None)
+        except AttributeError:
+            pass
+
 
 error = RuntimeError(
     "This field is created via field(frozen=True) but the @semimutable.dataclass decorator is not used on the dataclass. "

--- a/tests/test_semimutable_dataclass.py
+++ b/tests/test_semimutable_dataclass.py
@@ -27,6 +27,17 @@ def test_non_frozen_field_is_mutable():
     sm.y = 42
 
 
+def test_frozen_field_can_be_deleted():
+    @dataclass(slots=True)
+    class Sm:
+        x: int = field(frozen=True)
+
+    sm = Sm(x=1)
+    del sm.x
+    with pytest.raises(AttributeError):
+        sm.x
+
+
 def test_plain_dataclass_is_refused():
     with pytest.raises(RuntimeError):
 


### PR DESCRIPTION
## Summary
- support deleting frozen fields by implementing `FrozenField.__delete__`
- test that removing a frozen field raises `AttributeError` on later access

## Testing
- `python -m ruff check semimutable/__init__.py tests/test_semimutable_dataclass.py`
- `python -m ruff format semimutable/__init__.py tests/test_semimutable_dataclass.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68958e5da25883229d6b1884b08b4ffd