### PR TITLE
Skip InitVar fields when freezing

### DIFF
--- a/semimutable/__init__.py
+++ b/semimutable/__init__.py
@@ -27,12 +27,13 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     _MISSING_TYPE = Never
+    _FIELD_INITVAR: object
 
     # The type hints should match the actual implementation.
     def _get_slots(cls: type) -> Generator[str, None, None]:
         raise RuntimeError
 else:
-    from dataclasses import _MISSING_TYPE, _get_slots
+    from dataclasses import _FIELD_INITVAR, _MISSING_TYPE, _get_slots
 
 __version__ = "0.2.0"
 
@@ -375,6 +376,8 @@ def _freeze_fields[T](
     # Now we can iterate over the fields and replace the frozen fields (those with "frozen" in their metadata, as set by field(frozen=True))
     # with FrozenField descriptors.
     for f in fields(cls):  # pyright: ignore[reportArgumentType]  # cls must be a dataclass
+        if f._field_type is _FIELD_INITVAR:
+            continue
         if "frozen" in f.metadata:
             setattr(new_cls, f.name, FrozenField(f.name))
             descriptor_vars.add(f.name)

--- a/tests/test_semimutable_dataclass.py
+++ b/tests/test_semimutable_dataclass.py
@@ -2,7 +2,7 @@ import dataclasses
 
 import pytest
 
-from semimutable import FrozenFieldError, dataclass, field
+from semimutable import FrozenFieldError, InitVar, dataclass, field
 
 
 def test_frozen_field_is_immutable():
@@ -61,3 +61,16 @@ def test_classvar_assignment_error_raises():
 
     with pytest.raises(FrozenFieldError):
         Sm.x = 10
+
+
+def test_frozen_initvar_field_not_descriptor():
+    @dataclass
+    class Sm:
+        x: InitVar[int] = field(frozen=True)
+
+    sm = Sm(x=1)
+
+    with pytest.raises(AttributeError):
+        sm.x
+
+    assert "x" not in Sm.__dict__


### PR DESCRIPTION
## Summary
- avoid freezing InitVar fields when applying descriptors
- test that frozen InitVar parameters vanish after initialization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68958e5e6e3c8322afe648ab0ede4aa9