### PR TITLE
Ensure semimutable vars show public names

### DIFF
--- a/tests/test_semimutable_dataclass.py
+++ b/tests/test_semimutable_dataclass.py
@@ -3,6 +3,7 @@ import dataclasses
 import pytest
 
 from semimutable import FrozenFieldError, dataclass, field
+from semimutable import FROZEN_PREFIX
 
 
 def test_frozen_field_is_immutable():
@@ -61,3 +62,15 @@ def test_classvar_assignment_error_raises():
 
     with pytest.raises(FrozenFieldError):
         Sm.x = 10
+
+
+def test_vars_lists_public_field_names_only():
+    @dataclass(slots=False)
+    class Sm:
+        x: int = field(frozen=True)
+        y: int = 0
+
+    sm = Sm(x=1, y=2)
+    d = vars(sm)
+    assert d == {"x": 1, "y": 2}
+    assert FROZEN_PREFIX + "x" not in d


### PR DESCRIPTION
## Summary
- Mirror frozen field values under both public and private keys so `vars()` exposes public names
- Rework class freezing to reserve slots for private fields while retaining a `__dict__`
- Add regression test confirming `vars()` outputs only public field names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68958e5b410c83229e0e5acf44cfed7c